### PR TITLE
Add compression and remove access logs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,4 +14,10 @@ server {
        location ~ ^/franz-manager(?:/(?:.*/)?([^.]+)$)? {
               try_files $uri /index.html;
        }
+
+        # Let's save some bytes
+        gzip on;
+
+        # We do not need access logs
+        access_log  off;
 }


### PR DESCRIPTION
In order to save some traffic bytes we activate gzip transport compression

We also remove access logs to avoid spamming logs aggregrator

Compression might have unexpected impact